### PR TITLE
Respect composer.json "target-dir" when linking dependencies

### DIFF
--- a/src/Composer2Nix/Generator.php
+++ b/src/Composer2Nix/Generator.php
@@ -150,7 +150,7 @@ class Generator
 
 		fwrite($handle, "let\n");
 		fwrite($handle, "  composerEnv = import ".Generator::composeNixFilePath($composerEnvFile)." {\n");
-		fwrite($handle, "    inherit (pkgs) stdenv writeTextFile fetchurl php unzip;\n");
+		fwrite($handle, "    inherit (pkgs) stdenv writeTextFile fetchurl php unzip jq;\n");
 		fwrite($handle, "  };\n");
 		fwrite($handle, "in\n");
 		fwrite($handle, "import ".Generator::composeNixFilePath($outputFile)." {\n");


### PR DESCRIPTION
This fixes https://github.com/svanderburg/composer2nix/issues/1.
This is a bit quick & dirty but does the job.
It adds `jq` as a dependency but it is quite light. You could certainly write a php script for that instead if you don't like this dependency.