### PR TITLE
 Implement option --sources-only

### DIFF
--- a/bin/composer2nix
+++ b/bin/composer2nix
@@ -43,6 +43,9 @@ Options:
                          This is more space efficient, but not all packages may
                          be able to load their dependencies if they depend on
                          symlink resolving (defaults to: false).
+     --sources-only
+                         Only generate an expression containing the source
+                         descriptions.
  -h, --help              Shows the usage of this command
  -v, --version           Shows the version of this command
 
@@ -71,6 +74,7 @@ $options = getopt("p:hv", array(
 	"executable",
 	"no-copy-composer-env",
 	"symlink-deps",
+	"sources-only",
 	"help",
 	"version"
 ));
@@ -153,16 +157,18 @@ $symlinkDependencies = array_key_exists("symlink-deps", $options);
 
 $executable = array_key_exists("executable", $options);
 
+$sourcesOnly = array_key_exists("sources-only", $options);
+
 /* Execute the generator */
 
 try
 {
 	if($package === null)
-		Generator::generateNixExpressions($name, $executable, $preferredInstall, $noDev, $configFile, $lockFile, $outputFile, $compositionFile, $composerEnvFile, $noCopyComposerEnv, $symlinkDependencies);
+		Generator::generateNixExpressions($name, $executable, $preferredInstall, $noDev, $configFile, $lockFile, $outputFile, $compositionFile, $composerEnvFile, $noCopyComposerEnv, $symlinkDependencies, $sourcesOnly);
 	else
 	{
 		Composer::composePackageFromDependency($package, $versionSpec, $preferredInstall, $noDev);
-		Generator::generateNixExpressions($package, true, $preferredInstall, $noDev, "composer.json", "composer.lock", $outputFile, $compositionFile, $composerEnvFile, $noCopyComposerEnv, $symlinkDependencies);
+		Generator::generateNixExpressions($package, true, $preferredInstall, $noDev, "composer.json", "composer.lock", $outputFile, $compositionFile, $composerEnvFile, $noCopyComposerEnv, $symlinkDependencies, $sourcesOnly);
 	}
 }
 catch(Exception $ex)

--- a/src/Composer2Nix/Expressions/PackagesExpression.php
+++ b/src/Composer2Nix/Expressions/PackagesExpression.php
@@ -22,6 +22,9 @@ class PackagesExpression extends NixASTNode
 	/** Contains all properties of the composer package to deploy */
 	public $package;
 
+	/** should only an attrSet expression with packages and devPackages be created? */
+	public $sourcesOnly;
+
 	/**
 	 * Creates a new packages expression instance.
 	 *
@@ -29,10 +32,12 @@ class PackagesExpression extends NixASTNode
 	 * @param bool $executable Specifies whether the package to be deployed is an executable project
 	 * @param bool $symlinkDependencies Specifies whether the dependencies should be symlinked
 	 * @param string $preferredInstall Specifies the preferred installation source ('dist' or 'source')
+	 * @param bool $sourcesOnly Specifies whether the expression should only contain the sources attrSet
 	 */
-	public function __construct(ComposerConfig $composerConfig, $executable, $symlinkDependencies, $preferredInstall)
+	public function __construct(ComposerConfig $composerConfig, $executable, $symlinkDependencies, $preferredInstall, $sourcesOnly)
 	{
 		$this->executable = $executable;
+		$this->sourcesOnly = $sourcesOnly;
 		$this->sourcesCache = new SourcesCache($composerConfig, $preferredInstall);
 		$this->package = new Package($composerConfig, $executable, $symlinkDependencies);
 	}
@@ -57,7 +62,9 @@ class PackagesExpression extends NixASTNode
 			"fetchhg" => null,
 			"fetchsvn" => null,
 			"noDev" => false
-		), new NixLet($this->sourcesCache->toNixAST(), $this->package));
+		), $this->sourcesOnly
+			? $this->sourcesCache->toNixAST()
+			: new NixLet($this->sourcesCache->toNixAST(), $this->package));
 	}
 }
 ?>

--- a/src/Composer2Nix/Generator.php
+++ b/src/Composer2Nix/Generator.php
@@ -18,9 +18,9 @@ class Generator
 		fclose($handle);
 	}
 
-	private static function generatePackagesExpression($outputFile, ComposerConfig $config, $executable, $symlinkDependencies, $preferredInstall)
+	private static function generatePackagesExpression($outputFile, ComposerConfig $config, $executable, $symlinkDependencies, $preferredInstall, $sourcesOnly)
 	{
-		$expr = new PackagesExpression($config, $executable, $symlinkDependencies, $preferredInstall);
+		$expr = new PackagesExpression($config, $executable, $symlinkDependencies, $preferredInstall, $sourcesOnly);
 		$expr->fetchSources();
 		Generator::writeExprToFile($outputFile, $expr);
 	}
@@ -50,11 +50,12 @@ class Generator
 	 * @param string $composerEnvFile Path to the composer build environment Nix expression
 	 * @param bool $noCopyComposerEnv When set to true the composer build environment expression will not be copied
 	 * @param bool $symlinkDependencies Specifies whether the dependencies should be symlinked
+	 * @param bool $sourcesOnly Specifies whether the expression should only contain the sources attrSet
 	 */
-	public static function generateNixExpressions($name, $executable, $preferredInstall, $noDev, $configFile, $lockFile, $outputFile, $compositionFile, $composerEnvFile, $noCopyComposerEnv, $symlinkDependencies)
+	public static function generateNixExpressions($name, $executable, $preferredInstall, $noDev, $configFile, $lockFile, $outputFile, $compositionFile, $composerEnvFile, $noCopyComposerEnv, $symlinkDependencies, $sourcesOnly)
 	{
 		$composerConfig = new ComposerConfig($configFile, $lockFile, $name, $noDev);
-		Generator::generatePackagesExpression($outputFile, $composerConfig, $executable, $symlinkDependencies, $preferredInstall);
+		Generator::generatePackagesExpression($outputFile, $composerConfig, $executable, $symlinkDependencies, $preferredInstall, $sourcesOnly);
 		Generator::generateCompositionExpression($compositionFile, $outputFile, $composerEnvFile);
 		Generator::copyComposerEnv($composerEnvFile, $noCopyComposerEnv);
 	}


### PR DESCRIPTION
 The purpose of this flag is to change the result of evaluating
 default.nix from a derivation to only an AttrSet containing the
 source descriptions for all composer dependencies.
 (packages + devPackages)

 This is useful for fetching wordpress themes and plugins from
 wpackagist.

If you have thoughts about how to achieve this in a different way,
i'm open to suggestions!