### PR TITLE
Use nixpkgs' phpPackages.composer

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
 let
   composerEnv = import ./src/Composer2Nix/composer-env.nix {
     inherit (pkgs) stdenv writeTextFile fetchurl php unzip;
+    inherit (pkgs.phpPackages) composer;
   };
 in
 import ./php-packages.nix {

--- a/src/Composer2Nix/Composer.php
+++ b/src/Composer2Nix/Composer.php
@@ -64,7 +64,7 @@ class Composer
 		else if($preferredInstall == "dist")
 			$params .= " --prefer-dist";
 
-		$composerPath = shell_exec("nix-build --no-out-link -E 'let pkgs = import <nixpkgs> {}; composerEnv = import ".__DIR__."/composer-env.nix { inherit (pkgs) stdenv writeTextFile fetchurl php unzip; }; in composerEnv.composer'");
+		$composerPath = shell_exec("nix-build --no-out-link -E 'let pkgs = import <nixpkgs> {}; phpPackages.composer'");
 		if($composerPath === false)
 			throw new Exception("Cannot deploy the composer Nix package!");
 

--- a/src/Composer2Nix/Expressions/CompositionExpression.php
+++ b/src/Composer2Nix/Expressions/CompositionExpression.php
@@ -81,7 +81,8 @@ class CompositionExpression extends NixASTNode
 				"writeTextFile" => new NixInherit("pkgs"),
 				"fetchurl" => new NixInherit("pkgs"),
 				"php" => new NixInherit("pkgs"),
-				"unzip" => new NixInherit("pkgs")
+				"unzip" => new NixInherit("pkgs"),
+				"composer" => new NixInherit("pkgs.phpPackages")
 			))
 		), new NixFunInvocation(new NixImport(new NixFile($this->prefixRelativePath($this->outputFile))), array(
 			"composerEnv" => new NixInherit(),

--- a/src/Composer2Nix/composer-env.nix
+++ b/src/Composer2Nix/composer-env.nix
@@ -1,41 +1,8 @@
 # This file originates from composer2nix
 
-{ stdenv, writeTextFile, fetchurl, php, unzip }:
+{ stdenv, writeTextFile, fetchurl, php, unzip, composer }:
 
 let
-  composer = stdenv.mkDerivation {
-    name = "composer-1.6.5";
-    src = fetchurl {
-      url = https://github.com/composer/composer/releases/download/1.6.5/composer.phar;
-      sha256 = "07xkpg9y1dd4s33y3cbf7r5fphpgc39mpm066a8m9y4ffsf539f0";
-    };
-    buildInputs = [ php ];
-
-    # We must wrap the composer.phar because of the impure shebang.
-    # We cannot use patchShebangs because the executable verifies its own integrity and will detect that somebody has tampered with it.
-
-    buildCommand = ''
-      # Copy phar file
-      mkdir -p $out/share/php
-      cp $src $out/share/php/composer.phar
-      chmod 755 $out/share/php/composer.phar
-
-      # Create wrapper executable
-      mkdir -p $out/bin
-      cat > $out/bin/composer <<EOF
-      #! ${stdenv.shell} -e
-      exec ${php}/bin/php $out/share/php/composer.phar "\$@"
-      EOF
-      chmod +x $out/bin/composer
-    '';
-    meta = {
-      description = "Dependency Manager for PHP";
-      #license = stdenv.licenses.mit;
-      maintainers = [ stdenv.lib.maintainers.sander ];
-      platforms = stdenv.lib.platforms.unix;
-    };
-  };
-
   buildZipPackage = { name, src }:
     stdenv.mkDerivation {
       inherit name src;
@@ -264,7 +231,6 @@ let
   } // extraArgs);
 in
 {
-  composer = stdenv.lib.makeOverridable composer;
   buildZipPackage = stdenv.lib.makeOverridable buildZipPackage;
   buildPackage = stdenv.lib.makeOverridable buildPackage;
 }


### PR DESCRIPTION
I don't know if there's a specific reason you have your own definition for composer or if nixpkgs just didn't have one until more recently, but if that's the only reason why it seems like a good idea to de-duplicate code.