### PR TITLE
Change autoloader requirement for bin file

### DIFF
--- a/bin/composer2nix
+++ b/bin/composer2nix
@@ -1,6 +1,27 @@
 #!/usr/bin/env php
 <?php
-require_once(dirname(__FILE__)."/../vendor/autoload.php");
+
+$autoloadLocations = [
+	getcwd() . '/vendor/autoload.php',
+	getcwd() . '/../../autoload.php',
+	__DIR__ . '/../vendor/autoload.php',
+	__DIR__ . '/../../../autoload.php',
+];
+$loaded = false;
+foreach ($autoloadLocations as $autoload) {
+	if (is_file($autoload)) {
+		require_once($autoload);
+		$loaded = true;
+	}
+}
+if (!$loaded) {
+	fwrite(STDERR,
+		'You must set up the project dependencies, run the following commands:' . PHP_EOL .
+		'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+		'php composer.phar install' . PHP_EOL
+	);
+	exit(1);
+}
 
 use Composer2Nix\Composer;
 use Composer2Nix\Generator;


### PR DESCRIPTION
Now the autoloader can be found within the repo itself, within a project dependency, or within a globally required copy.

To be honest, the code is just copied from a number of similar bin-providing composer projects.

This addresses issue #5  