### PR TITLE
call php scripts via php interpreter instead of relying on shebang

### DIFF
--- a/src/Composer2Nix/composer-env.nix
+++ b/src/Composer2Nix/composer-env.nix
@@ -174,7 +174,7 @@ let
 
         # Reconstruct the installed.json file from the lock file
         mkdir -p vendor/composer
-        ${reconstructInstalled} composer.lock > vendor/composer/installed.json
+        ${php}/bin/php ${reconstructInstalled} composer.lock > vendor/composer/installed.json
 
         # Copy or symlink the provided dependencies
         cd vendor
@@ -192,7 +192,7 @@ let
 
         ${stdenv.lib.optionalString executable ''
           # Reconstruct the bin/ folder if we deploy an executable project
-          ${constructBin} composer.json
+          ${php}/bin/php ${constructBin} composer.json
           ln -s $(pwd)/vendor/bin $out/bin
         ''}
 


### PR DESCRIPTION
## The problem

Looks like in recent versions of nixpkgs, `${php}/bin/php` is a shell script wrapping the actual php binary. The consequence is that it's not usable as a shebang in this state, and we can't build composer2nix.

```
$ nix-build -A package.x86_64-darwin --arg systems '[ "x86_64-darwin" ]' ./release.nix
[...]
/nix/store/5p443xmpksknmbdcipygsddrpl3jxk3b-reconstructinstalled.php: line 2: ?php: No such file or directory
/nix/store/5p443xmpksknmbdcipygsddrpl3jxk3b-reconstructinstalled.php: line 3: syntax error near unexpected token `$argv[1]'
/nix/store/5p443xmpksknmbdcipygsddrpl3jxk3b-reconstructinstalled.php: line 3: `if(file_exists($argv[1]))'
builder for '/nix/store/flmwgq14wkbknv1yl7yklcidi10zn8vb-composer-svanderburg-composer2nix.drv' failed with exit code 2
error: build of '/nix/store/flmwgq14wkbknv1yl7yklcidi10zn8vb-composer-svanderburg-composer2nix.drv' failed
```

## Proposed solution
Call the two php scripts in `composer-env.nix` via the php interpreter instead of relying on the shebang.