### PR TITLE
implement packageOverrides argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, noDev ? false}:
+  }, system ? builtins.currentSystem, noDev ? false, packageOverrides ? {}}:
 
 let
   composerEnv = import ./src/Composer2Nix/composer-env.nix {
@@ -8,6 +8,6 @@ let
   };
 in
 import ./php-packages.nix {
-  inherit composerEnv noDev;
+  inherit composerEnv noDev packageOverrides;
   inherit (pkgs) fetchurl fetchgit fetchhg fetchsvn;
 }

--- a/php-packages.nix
+++ b/php-packages.nix
@@ -1,4 +1,4 @@
-{composerEnv, fetchurl, fetchgit ? null, fetchhg ? null, fetchsvn ? null, noDev ? false}:
+{composerEnv, fetchurl, fetchgit ? null, fetchhg ? null, fetchsvn ? null, noDev ? false, packageOverrides}:
 
 let
   packages = {
@@ -547,7 +547,7 @@ let
   };
 in
 composerEnv.buildPackage {
-  inherit packages devPackages noDev;
+  inherit packages devPackages packageOverrides noDev;
   name = "svanderburg-composer2nix";
   src = ./.;
   executable = true;

--- a/src/Composer2Nix/Expressions/CompositionExpression.php
+++ b/src/Composer2Nix/Expressions/CompositionExpression.php
@@ -3,6 +3,7 @@ namespace Composer2Nix\Expressions;
 use PNDP\NixGenerator;
 use PNDP\AST\NixAttrReference;
 use PNDP\AST\NixASTNode;
+use PNDP\AST\NixAttrSet;
 use PNDP\AST\NixExpression;
 use PNDP\AST\NixFunction;
 use PNDP\AST\NixFunInvocation;
@@ -74,7 +75,8 @@ class CompositionExpression extends NixASTNode
 				"system" => new NixInherit()
 			)),
 			"system" => new NixAttrReference(new NixExpression("builtins"), new NixExpression("currentSystem")),
-			"noDev" => false
+			"noDev" => false,
+			"packageOverrides" => new NixAttrSet(array())
 		), new NixLet(array(
 			"composerEnv" => new NixFunInvocation(new NixImport(new NixFile($this->prefixRelativePath($this->composerEnvFile))), array(
 				"stdenv" => new NixInherit("pkgs"),
@@ -88,6 +90,7 @@ class CompositionExpression extends NixASTNode
 		), new NixFunInvocation(new NixImport(new NixFile($this->prefixRelativePath($this->outputFile))), array(
 			"composerEnv" => new NixInherit(),
 			"noDev" => new NixInherit(),
+			"packageOverrides" => new NixInherit(),
 			"fetchurl" => new NixInherit("pkgs"),
 			"fetchgit" => new NixInherit("pkgs"),
 			"fetchhg" => new NixInherit("pkgs"),

--- a/src/Composer2Nix/Expressions/PackagesExpression.php
+++ b/src/Composer2Nix/Expressions/PackagesExpression.php
@@ -56,7 +56,8 @@ class PackagesExpression extends NixASTNode
 			"fetchgit" => null,
 			"fetchhg" => null,
 			"fetchsvn" => null,
-			"noDev" => false
+			"noDev" => false,
+			"packageOverrides" => new NixNoDefault()
 		), new NixLet($this->sourcesCache->toNixAST(), $this->package));
 	}
 }

--- a/src/Composer2Nix/Package.php
+++ b/src/Composer2Nix/Package.php
@@ -71,6 +71,7 @@ class Package extends NixASTNode
 			"executable" => $this->executable,
 			"packages" => new NixInherit(),
 			"devPackages" => new NixInherit(),
+			"packageOverrides" => new NixInherit(),
 			"noDev" => new NixInherit(),
 			"symlinkDependencies" => $this->symlinkDependencies,
 			"meta" => $this->generatePackageMetaDataAST()

--- a/tests/dependencies/default.nix
+++ b/tests/dependencies/default.nix
@@ -1,6 +1,6 @@
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, noDev ? false}:
+  }, system ? builtins.currentSystem, noDev ? false, packageOverrides ? {}}:
 
 let
   composerEnv = import ../../src/Composer2Nix/composer-env.nix {
@@ -8,6 +8,6 @@ let
   };
 in
 import ./php-packages.nix {
-  inherit composerEnv noDev;
+  inherit composerEnv noDev packageOverrides;
   inherit (pkgs) fetchurl fetchgit fetchhg fetchsvn;
 }

--- a/tests/dependencies/php-packages.nix
+++ b/tests/dependencies/php-packages.nix
@@ -1,4 +1,4 @@
-{composerEnv, fetchurl, fetchgit ? null, fetchhg ? null, fetchsvn ? null, noDev ? false}:
+{composerEnv, fetchurl, fetchgit ? null, fetchhg ? null, fetchsvn ? null, noDev ? false, packageOverrides}:
 
 let
   packages = {
@@ -795,7 +795,7 @@ let
   devPackages = {};
 in
 composerEnv.buildPackage {
-  inherit packages devPackages noDev;
+  inherit packages devPackages packageOverrides noDev;
   name = "dependencies";
   src = ./.;
   executable = false;

--- a/tests/enduser/default.nix
+++ b/tests/enduser/default.nix
@@ -1,6 +1,6 @@
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, noDev ? false}:
+  }, system ? builtins.currentSystem, noDev ? false, packageOverrides ? {}}:
 
 let
   composerEnv = import ../../src/Composer2Nix/composer-env.nix {
@@ -8,6 +8,6 @@ let
   };
 in
 import ./php-packages.nix {
-  inherit composerEnv noDev;
+  inherit composerEnv noDev packageOverrides;
   inherit (pkgs) fetchurl fetchgit fetchhg fetchsvn;
 }

--- a/tests/enduser/php-packages.nix
+++ b/tests/enduser/php-packages.nix
@@ -1,4 +1,4 @@
-{composerEnv, fetchurl, fetchgit ? null, fetchhg ? null, fetchsvn ? null, noDev ? false}:
+{composerEnv, fetchurl, fetchgit ? null, fetchhg ? null, fetchsvn ? null, noDev ? false, packageOverrides}:
 
 let
   packages = {
@@ -306,7 +306,7 @@ let
   devPackages = {};
 in
 composerEnv.buildPackage {
-  inherit packages devPackages noDev;
+  inherit packages devPackages packageOverrides noDev;
   name = "phpunit-phpunit";
   src = ./.;
   executable = true;


### PR DESCRIPTION
This makes it so the generated nix expressions accept the argument `packageOverrides`, which allows users to override the derivations of dependencies.
This is desirable in the case that a dependency cannot be built with nix as-is -- my motivating case was a package that wanted to make network requests in `post-install-cmd`.

`packageOverrides` should be an attrset whose values are a function from the old derivation to a new one.

Here is an example:
```
packageOverrides = {
  "podlibre/ipcat" = oldPkg: applyPatches {
    src = oldPkg;
    patches = [(substituteAll {
      src = ./datacenters.patch;
      datacenters = "${ipcat}/datacenters.csv";
    })];
  };
};
```