### PR TITLE
Move unzip to nativeBuildInputs

### DIFF
--- a/src/Composer2Nix/composer-env.nix
+++ b/src/Composer2Nix/composer-env.nix
@@ -7,7 +7,7 @@ let
   buildZipPackage = { name, src }:
     stdenv.mkDerivation {
       inherit name src;
-      buildInputs = [ unzip ];
+      nativeBuildInputs = [ unzip ];
       buildCommand = ''
         unzip $src
         baseDir=$(find . -type d -mindepth 1 -maxdepth 1)


### PR DESCRIPTION
Otherwise the wrong binary is provided when cross compiling